### PR TITLE
Adds print and export to PDF actions

### DIFF
--- a/src/Widgets/Toolbar.vala
+++ b/src/Widgets/Toolbar.vala
@@ -8,6 +8,7 @@ class Toolbar : Gtk.HeaderBar {
     private MenuButton export_button;
     private Gtk.MenuItem export_pdf;
     private Gtk.MenuItem export_html;
+    private Gtk.MenuItem export_print;
 
     private MenuButton settings_button;
     private Gtk.MenuItem about;
@@ -17,6 +18,7 @@ class Toolbar : Gtk.HeaderBar {
     public signal void save_clicked ();
     public signal void export_html_clicked ();
     public signal void export_pdf_clicked ();
+    public signal void export_print_clicked ();
     public signal void about_clicked ();
 
     public Toolbar () {
@@ -43,11 +45,12 @@ class Toolbar : Gtk.HeaderBar {
 
         var export_menu = new Gtk.Menu ();
         export_pdf = new Gtk.MenuItem.with_label (_("Export PDF"));
-
         export_html = new Gtk.MenuItem.with_label (_("Export HTML"));
+        export_print = new Gtk.MenuItem.with_label (_("Print"));
 
         export_menu.add (export_html);
         export_menu.add (export_pdf);
+        export_menu.add (export_print);
         export_menu.show_all ();
 
         export_button.set_popup (export_menu);
@@ -90,6 +93,10 @@ class Toolbar : Gtk.HeaderBar {
 
         export_html.activate.connect (() => {
             export_html_clicked ();
+        });
+
+        export_print.activate.connect (() => {
+            export_print_clicked ();
         });
 
         about.activate.connect (() => {

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -116,6 +116,7 @@ public class Window : Gtk.Window {
         toolbar.save_clicked.connect (save_action);
         toolbar.export_html_clicked.connect (export_html_action);
         toolbar.export_pdf_clicked.connect (export_pdf_action);
+        toolbar.export_print_clicked.connect (export_print_action);
         toolbar.about_clicked.connect (about_action);
     }
 
@@ -226,6 +227,26 @@ public class Window : Gtk.Window {
 
     private void export_pdf_action () {
         var file = get_file_from_user (DialogType.PDF_OUT);
+
+        try { // TODO: we have to write an empty file so we can get file path
+            FileHandler.write_file (file, "");
+        } catch (Error e) {
+            warning ("Could not write initial PDF file: %s", e.message);
+            return;
+        }
+
+        var op = new WebKit.PrintOperation (html_view);
+        var settings = new Gtk.PrintSettings ();
+        settings.set_printer (dgettext ("gtk30", "Print to File"));
+        settings[Gtk.PRINT_SETTINGS_OUTPUT_URI] = "file://" + file.get_path ();
+        op.set_print_settings (settings);
+
+        op.print ();
+    }
+
+    private void export_print_action () {
+        var op = new WebKit.PrintOperation (html_view);
+        op.run_dialog (this);
     }
 
     private void about_action () {


### PR DESCRIPTION
Adds:
* Export to PDF
* Printing

It uses `WebKit.PrintOperation` which is better than `Pango.Layout` because the last one doesn't support HTML and we would have to set font size/position/everything else by hand.

Based on http://fossies.org/linux/WebKit/Tools/TestWebKitAPI/Tests/WebKit2Gtk/TestPrinting.cpp