### PR TITLE
Add dummies ids for GTK < 3.11.2

### DIFF
--- a/resources/headerbar.ui
+++ b/resources/headerbar.ui
@@ -5,14 +5,14 @@
     <property name="visible">True</property>
     <property name="show-close-button">True</property>
     <child>
-      <object class="GtkButton">
+      <object class="GtkButton" id="newFileButton">
         <property name="visible">True</property>
         <property name="tooltip-text" translatable="yes">New file</property>
         <property name="use-underline">True</property>
         <property name="action-name">win.new</property>
         <style><class name="image-button"/></style>
         <child>
-          <object class="GtkImage">
+          <object class="GtkImage" id="newFileIcon">
             <property name="icon-name">document-new</property>
             <property name="visible">True</property>
             <property name="icon-size">3</property>
@@ -21,14 +21,14 @@
       </object>
     </child>
     <child>
-      <object class="GtkButton">
+      <object class="GtkButton" id="openFileButton">
         <property name="visible">True</property>
         <property name="tooltip-text" translatable="yes">Open file</property>
         <property name="use-underline">True</property>
         <property name="action-name">win.open</property>
         <style><class name="image-button"/></style>
         <child>
-          <object class="GtkImage">
+          <object class="GtkImage" id="openFileIcon">
             <property name="icon-name">document-open</property>
             <property name="visible">True</property>
             <property name="icon-size">3</property>
@@ -37,14 +37,14 @@
       </object>
     </child>
     <child>
-      <object class="GtkButton">
+      <object class="GtkButton" id="saveFileButton">
         <property name="visible">True</property>
         <property name="tooltip-text" translatable="yes">Save file</property>
         <property name="use-underline">True</property>
         <property name="action-name">win.save</property>
         <style><class name="image-button"/></style>
         <child>
-          <object class="GtkImage">
+          <object class="GtkImage" id="saveFileIcon">
             <property name="icon-name">document-save</property>
             <property name="visible">True</property>
             <property name="icon-size">3</property>
@@ -53,7 +53,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkMenuButton">
+      <object class="GtkMenuButton" id="prefMenuButton">
         <property name="visible">True</property>
         <!-- <property name="tooltip-text" translatable="yes">Preferences</property>
         <property name="use-underline">True</property> -->
@@ -84,7 +84,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkMenuButton">
+      <object class="GtkMenuButton" id="exportMenuButton">
         <property name="visible">True</property>
         <!-- <property name="tooltip-text" translatable="yes">Export</property>
         <property name="use-underline">True</property> -->

--- a/resources/toolbar.ui
+++ b/resources/toolbar.ui
@@ -15,10 +15,10 @@
     <property name="visible">True</property>
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkToolbar">
+      <object class="GtkToolbar" id="">
         <property name="visible">True</property>
         <child>
-          <object class="GtkToolButton">
+          <object class="GtkToolButton" id="newFileToolButton">
             <property name="visible">True</property>
             <property name="tooltip-text" translatable="yes">New file</property>
             <property name="use-underline">True</property>
@@ -27,7 +27,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkToolButton">
+          <object class="GtkToolButton" id="openFileToolButton">
             <property name="visible">True</property>
             <property name="tooltip-text" translatable="yes">Open file</property>
             <property name="use-underline">True</property>
@@ -36,7 +36,7 @@
           </object>
         </child>
         <child>
-          <object class="GtkToolButton">
+          <object class="GtkToolButton" id="saveFileToolButton">
             <property name="visible">True</property>
             <property name="tooltip-text" translatable="yes">Save file</property>
             <property name="use-underline">True</property>
@@ -45,23 +45,23 @@
           </object>
         </child>
         <child>
-          <object class="GtkMenuToolButton">
+          <object class="GtkMenuToolButton" id="prefToolButton">
             <property name="visible">True</property>
             <!-- <property name="tooltip-text" translatable="yes">Preferences</property>
             <property name="use-underline">True</property> -->
             <property name="icon-widget">fallback1</property>
             <child type="menu">
-              <object class="GtkMenu">
+              <object class="GtkMenu" id="prefMenu">
                 <property name="visible">True</property>
                 <child>
-                  <object class="GtkMenuItem">
+                  <object class="GtkMenuItem" id="prefMenuItem">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">Preferences</property>
                     <property name="action-name">win.preferences</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkMenuItem">
+                  <object class="GtkMenuItem" id="aboutMenuItem">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">About</property>
                     <property name="action-name">win.about</property>
@@ -72,30 +72,30 @@
           </object>
         </child>
         <child>
-          <object class="GtkMenuToolButton">
+          <object class="GtkMenuToolButton" id="exportMenuButton">
             <property name="visible">True</property>
             <!-- <property name="tooltip-text" translatable="yes">Export</property>
             <property name="use-underline">True</property> -->
             <property name="icon-widget">fallback2</property>
             <child type="menu">
-              <object class="GtkMenu">
+              <object class="GtkMenu" id="exportSubMenu">
                 <property name="visible">True</property>
                 <child>
-                  <object class="GtkMenuItem">
+                  <object class="GtkMenuItem" id="exportPDFItem">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">Export PDF</property>
                     <property name="action-name">win.pdf</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkMenuItem">
+                  <object class="GtkMenuItem" id="exportHTMLItem">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">Export HTML</property>
                     <property name="action-name">win.html</property>
                   </object>
                 </child>
                 <child>
-                  <object class="GtkMenuItem">
+                  <object class="GtkMenuItem" id="printItem">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">Print</property>
                     <property name="action-name">win.print</property>


### PR DESCRIPTION
The file resources/ui/toolbar.ui lacks an id attribute for most object
elements. Prior to GTK 3.11.2 they were required and so MarkMyWords fails to
start.

https://bugzilla.gnome.org/show_bug.cgi?id=712553
http://ftp.gnome.org/pub/gnome/sources/gtk+/3.11/gtk+-3.11.2.news