### PR TITLE
Added the ability to copy selected text to HTML.

### DIFF
--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -29,6 +29,14 @@ public class DocumentView : Gtk.ScrolledWindow {
         return code_view.buffer.text;
     }
 
+    public string get_selected_text () {
+        var start = Gtk.TextIter();
+        var end = Gtk.TextIter();
+        code_view.buffer.get_selection_bounds(out start, out end);
+        stdout.printf(code_view.buffer.get_text(start, end, true));
+        return code_view.buffer.get_text(start, end, true);
+    }
+
     public void give_focus () {
         code_view.grab_focus ();
     }

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -33,7 +33,6 @@ public class DocumentView : Gtk.ScrolledWindow {
         var start = Gtk.TextIter();
         var end = Gtk.TextIter();
         code_view.buffer.get_selection_bounds(out start, out end);
-        stdout.printf(code_view.buffer.get_text(start, end, true));
         return code_view.buffer.get_text(start, end, true);
     }
 

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -512,7 +512,7 @@ public class Window : Gtk.ApplicationWindow {
         return map;
     }
 
-    private string process (string raw_mk) {
+    private string process (string raw_mk, bool has_enclosing_tags=true) {
         string processed_mk;
         process_frontmatter (raw_mk, out processed_mk);
 
@@ -522,34 +522,28 @@ public class Window : Gtk.ApplicationWindow {
         string result;
         mkd.get_document (out result);
 
-        string html = "<html><head>";
-        if (prefs.render_stylesheet) {
-            html += "<style>"+render_stylesheet+"</style>";
+        string html = "";
+        if (has_enclosing_tags) {
+            html += "<html><head>";
+            if (prefs.render_stylesheet) {
+                html += "<style>"+render_stylesheet+"</style>";
+            }
+            if (prefs.render_syntax_highlighting) {
+                html += "<style>"+syntax_stylesheet+"</style>";
+                html += "<script>"+syntax_script+"</script>";
+                html += "<script>hljs.initHighlightingOnLoad();</script>";
+            }
+
+            html += "</head><body><div class=\"markdown-body\">";
         }
-        if (prefs.render_syntax_highlighting) {
-            html += "<style>"+syntax_stylesheet+"</style>";
-            html += "<script>"+syntax_script+"</script>";
-            html += "<script>hljs.initHighlightingOnLoad();</script>";
-        }
-        html += "</head><body><div class=\"markdown-body\">";
         html += result;
-        html += "</div></body></html>";
+        if (has_enclosing_tags) {
+            html += "</div></body></html>";
+        }
 
         return html;
     }
 
-    private string process_selection (string raw_mk) {
-        string processed_mk;
-        process_frontmatter (raw_mk, out processed_mk);
-
-        var mkd = new Markdown.Document (processed_mk.data);
-        mkd.compile ();
-
-        string result;
-        mkd.get_document (out result);
-
-        return result;
-    }
 
     private void update_html_view () {
         string text = doc.get_text ();
@@ -609,7 +603,7 @@ public class Window : Gtk.ApplicationWindow {
 
     private void copy_html_action () {
         string text = doc.get_selected_text ();
-        string html = process_selection (text);
+        string html = process (text, false);
 
         try {
             clipboard.set_text (html, -1);

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -512,7 +512,7 @@ public class Window : Gtk.ApplicationWindow {
         return map;
     }
 
-    private string process (string raw_mk, bool has_enclosing_tags=true) {
+    private string process (string raw_mk) {
         string processed_mk;
         process_frontmatter (raw_mk, out processed_mk);
 
@@ -522,28 +522,27 @@ public class Window : Gtk.ApplicationWindow {
         string result;
         mkd.get_document (out result);
 
-        string html = "";
-        if (has_enclosing_tags) {
-            html += "<html><head>";
-            if (prefs.render_stylesheet) {
-                html += "<style>"+render_stylesheet+"</style>";
-            }
-            if (prefs.render_syntax_highlighting) {
-                html += "<style>"+syntax_stylesheet+"</style>";
-                html += "<script>"+syntax_script+"</script>";
-                html += "<script>hljs.initHighlightingOnLoad();</script>";
-            }
+        return result;
+    }
 
-            html += "</head><body><div class=\"markdown-body\">";
+    private string process_page (string raw_mk) {
+        string html = "";
+        html += "<html><head>";
+        if (prefs.render_stylesheet) {
+            html += "<style>"+render_stylesheet+"</style>";
         }
-        html += result;
-        if (has_enclosing_tags) {
-            html += "</div></body></html>";
+        if (prefs.render_syntax_highlighting) {
+            html += "<style>"+syntax_stylesheet+"</style>";
+            html += "<script>"+syntax_script+"</script>";
+            html += "<script>hljs.initHighlightingOnLoad();</script>";
         }
+
+        html += "</head><body><div class=\"markdown-body\">";
+        html += process(raw_mk);
+        html += "</div></body></html>";
 
         return html;
     }
-
 
     private void update_html_view () {
         string text = doc.get_text ();
@@ -603,7 +602,7 @@ public class Window : Gtk.ApplicationWindow {
 
     private void copy_html_action () {
         string text = doc.get_selected_text ();
-        string html = process (text, false);
+        string html = process (text);
 
         try {
             clipboard.set_text (html, -1);
@@ -616,7 +615,7 @@ public class Window : Gtk.ApplicationWindow {
         var file = get_file_from_user (DialogType.HTML_OUT);
 
         string text = doc.get_text ();
-        string html = process (text);
+        string html = process_page (text);
 
         try {
             FileHandler.write_file (file, html);

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -540,6 +540,19 @@ public class Window : Gtk.ApplicationWindow {
         return html;
     }
 
+    private string process_selection (string raw_mk) {
+        string processed_mk;
+        process_frontmatter (raw_mk, out processed_mk);
+
+        var mkd = new Markdown.Document (processed_mk.data);
+        mkd.compile ();
+
+        string result;
+        mkd.get_document (out result);
+
+        return result;
+    }
+
     private void update_html_view () {
         string text = doc.get_text ();
         string html = process (text);
@@ -598,7 +611,7 @@ public class Window : Gtk.ApplicationWindow {
 
     private void copy_html_action () {
         string text = doc.get_selected_text ();
-        string html = process (text);
+        string html = process_selection (text);
 
         try {
             clipboard.set_text (html, -1);

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -311,12 +311,10 @@ public class Window : Gtk.ApplicationWindow {
         bool handled_event = false;
         bool ctrl_pressed = modifier_pressed (ev,
                                               Gdk.ModifierType.CONTROL_MASK);
-        bool shift_pressed = modifier_pressed (ev,
-                                              Gdk.ModifierType.SUPER_MASK);
 
         switch (ev.keyval) {
-        case Gdk.Key.c:
-            if (ctrl_pressed && shift_pressed) {
+        case Gdk.Key.C:
+            if (ctrl_pressed) {
                 handled_event = true;
                 copy_html_action ();
             }

--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -40,7 +40,6 @@ public class Window : Gtk.ApplicationWindow {
     // we'll make it render after 0.3 seconds
     private const int TIME_TO_REFRESH = 3 * 100;
 
-    private Gdk.Display display;
     private Gtk.Clipboard clipboard;
 
     public signal void updated ();
@@ -202,8 +201,7 @@ public class Window : Gtk.ApplicationWindow {
         load_window_state ();
         window_position = Gtk.WindowPosition.CENTER;
         set_hide_titlebar_when_maximized (false);
-        display = get_display();
-        clipboard = Gtk.Clipboard.get_for_display(display, Gdk.SELECTION_CLIPBOARD);
+        clipboard = Gtk.Clipboard.get_for_display(get_display(), Gdk.SELECTION_CLIPBOARD);
 
 
         var box = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);


### PR DESCRIPTION
I bound a new function copy_html_action() to the Ctrl+Super+C hotkey. This triggers the new get_selected_text() method inside the DocumentView class, which returns selection and runs it through the new  html process_selection function.

This implementation returns the minimum HTML result, meaning no enclosing html tags or embedded styles. Eventually I may write a clause that checks if the selection == the entire buffer, and if so, switch to the original process function that returns the enclosing html tags and embedded styles.