### PR TITLE
keep the divider at the same ratio during window resizes

### DIFF
--- a/src/Widgets/Window.vala
+++ b/src/Widgets/Window.vala
@@ -5,6 +5,7 @@ public class Window : Gtk.ApplicationWindow {
     private Preferences prefs;
     private SavedState saved_state;
     private Gtk.HeaderBar? headerbar = null;
+    private Gtk.Paned box;
 
     // current state
     private File? _current_file;
@@ -43,6 +44,24 @@ public class Window : Gtk.ApplicationWindow {
     private Gtk.Clipboard clipboard;
 
     public signal void updated ();
+
+    protected override bool configure_event(Gdk.EventConfigure event) {
+        // get the size of the window before it's resized
+        int width, height;
+        get_default_size (out width, out height);
+
+        // get the divider position and the position ratio
+        var divider_position = box.get_position ();
+        float ratio = (float)divider_position / (float)width;
+        // make it retain the same ratio even after resize
+        var new_pos = event.width * ratio;
+
+        // apply the new position to the window and divider
+        set_default_size (event.width, event.height);
+        box.set_position ((int)new_pos);
+
+        return true;
+    }
 
     // actions
     private const GLib.ActionEntry win_actions[] =
@@ -204,7 +223,7 @@ public class Window : Gtk.ApplicationWindow {
         clipboard = Gtk.Clipboard.get_for_display(get_display(), Gdk.SELECTION_CLIPBOARD);
 
 
-        var box = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
+        box = new Gtk.Paned (Gtk.Orientation.HORIZONTAL);
         box.expand = true;
 
         Gtk.Builder builder;


### PR DESCRIPTION
This commit adds the ability to keep keep a constant ratio between the editor/preview even during window resizes. This should be compatible with any DM's window snapping abilities as well, so if you keep it split 50/50, it'll remain 50/50 even when switching the window full screen to half screen.

I added this in because I was running into issues where I'd lose my preview window during window resizes in the previous builds, this fixes it. However, since it's more of a personal preference feature, perhaps maybe it would be best to add in a pref switch for this feature.

But to follow Elementary's software design guides, I think this is one of those features that's best made for the user, as leaving it on will not negatively effect any user (but leaving it off could negatively effect a user who has less screen real-estate)